### PR TITLE
Sample PR for paging requests and selector utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -721,6 +721,11 @@
 			<artifactId>client</artifactId>
 			<version>2.0.0</version>
 		</dependency>
+		<dependency>
+		  <groupId>commons-lang</groupId>
+		  <artifactId>commons-lang</artifactId>
+		  <version>2.6</version>
+		</dependency>
 	</dependencies>
 
 	<properties>

--- a/src/main/java/net/nikr/eve/jeveasset/io/evekit/AbstractEveKitGetter.java
+++ b/src/main/java/net/nikr/eve/jeveasset/io/evekit/AbstractEveKitGetter.java
@@ -31,6 +31,8 @@ import net.nikr.eve.jeveasset.Program;
 import net.nikr.eve.jeveasset.data.evekit.EveKitOwner;
 import net.nikr.eve.jeveasset.gui.dialogs.update.UpdateTask;
 import net.nikr.eve.jeveasset.gui.shared.Formater;
+
+import org.apache.commons.lang.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -181,4 +183,44 @@ public abstract class AbstractEveKitGetter {
 	protected abstract void setNextUpdate(EveKitOwner owner, Date date);
 	protected abstract ApiClient getApiClient();
 
+  /**
+   * Convenience methods for constructing EveKit attribute selectors. There are four possible selector types (as documented here:
+   * https://github.com/OrbitalEnterprises/evekit-model-frontend#usage):
+   * 
+   * <ol>
+   * <li>{any: <boolean>} - Wildcard selector. Normally, this is the default for a field, meaning you can usually omit using this selector.
+   * <li>{like: <string>} - String match selector. If the associated data field is string valued, then all returned model data must satisfy the SQL expression
+   * 'field LIKE selector'. Normal SQL 'LIKE' syntax is allowed (e.g. % as wildcard).
+   * <li>{values: [<v1>,...,<vn>]} - Set selector. The associated data field of each returned model data item must contain one of the listed values.
+   * <li>{start: <lower>, end: <upper>} - Range selector. The associated data field of each returned model data item must satisfy lower <= value <= upper.
+   * </ol>
+   * 
+   */
+  public static String ek_any() {
+    return "{ any: true }";
+  }
+
+  public static String ek_like(
+                               Object l) {
+    return "{ like: \"" + StringEscapeUtils.escapeJavaScript(String.valueOf(l)) + "\" }";
+  }
+
+  public static String ek_values(
+                                 Object... v) {
+    StringBuilder builder = new StringBuilder();
+    builder.append("{ values: [");
+    for (Object i : v)
+      builder.append("\"").append(StringEscapeUtils.escapeJavaScript(String.valueOf(i))).append("\",");
+    if (v.length > 0) builder.setLength(builder.length() - 1);
+    builder.append("] }");
+    return builder.toString();
+  }
+
+  public static String ek_range(
+                                Object start,
+                                Object end) {
+    return "{ start: \"" + StringEscapeUtils.escapeJavaScript(String.valueOf(start)) + "\", end: \"" + StringEscapeUtils.escapeJavaScript(String.valueOf(end))
+        + "\" }";
+  }
+	
 }

--- a/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitAccountBalanceGetter.java
+++ b/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitAccountBalanceGetter.java
@@ -40,6 +40,7 @@ public class EveKitAccountBalanceGetter extends AbstractEveKitGetter {
 
 	@Override
 	protected void get(EveKitOwner owner) throws ApiException {
+	  // As written, this will always get the latest account balances.  No changes needed.
 		List<AccountBalance> accountBalance = getCommonApi().getAccountBalance(owner.getAccessKey(), owner.getAccessCred(), null, null, Integer.MAX_VALUE, null,
 				null, null);
 		Date balanceLastUpdate = null;

--- a/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitBlueprintsGetter.java
+++ b/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitBlueprintsGetter.java
@@ -39,9 +39,25 @@ public class EveKitBlueprintsGetter extends AbstractEveKitGetter {
 	}
 
 	@Override
-	protected void get(EveKitOwner owner) throws ApiException {
-		List<Blueprint> blueprints = getCommonApi().getBlueprints(owner.getAccessKey(), owner.getAccessCred(), null, null, Integer.MAX_VALUE, null,
+	protected void get(final EveKitOwner owner) throws ApiException {
+	  // Return current blueprints.  Paging required for large blueprint lists.
+		List<Blueprint> blueprints = retrievePagedResults(new BatchRetriever<Blueprint>() {
+
+      @Override
+      public List<Blueprint> getNextBatch(
+                                          long contid)
+        throws ApiException {
+        return getCommonApi().getBlueprints(owner.getAccessKey(), owner.getAccessCred(), null, contid, Integer.MAX_VALUE, null,
 				null, null, null, null, null, null, null, null, null);
+      }
+
+      @Override
+      public long getCid(
+                         Blueprint obj) {
+        return obj.getCid();
+      }
+		  
+		}); 
 		owner.setBlueprints(EveKitConverter.convertBlueprints(blueprints));
 	}
 

--- a/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitJournalGetter.java
+++ b/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitJournalGetter.java
@@ -21,11 +21,13 @@
 package net.nikr.eve.jeveasset.io.evekit;
 
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 import enterprises.orbital.evekit.client.invoker.ApiClient;
 import enterprises.orbital.evekit.client.invoker.ApiException;
 import enterprises.orbital.evekit.client.model.WalletJournal;
-import java.util.Date;
-import java.util.List;
 import net.nikr.eve.jeveasset.data.evekit.EveKitAccessMask;
 import net.nikr.eve.jeveasset.data.evekit.EveKitOwner;
 import net.nikr.eve.jeveasset.gui.dialogs.update.UpdateTask;
@@ -40,8 +42,14 @@ public class EveKitJournalGetter extends AbstractEveKitGetter {
 
 	@Override
 	protected void get(EveKitOwner owner) throws ApiException {
-		List<WalletJournal> journalEntries = getCommonApi().getJournalEntries(owner.getAccessKey(), owner.getAccessCred(), null, null, Integer.MAX_VALUE, null,
+	  List<WalletJournal> journalEntries = new ArrayList<>();
+		List<WalletJournal> batch = getCommonApi().getJournalEntries(owner.getAccessKey(), owner.getAccessCred(), null, null, Integer.MAX_VALUE, null,
 				null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+		while (!batch.isEmpty()) {
+		  journalEntries.addAll(batch);
+		  batch = getCommonApi().getJournalEntries(owner.getAccessKey(), owner.getAccessCred(), null, batch.get(batch.size() - 1).getCid(), Integer.MAX_VALUE, null,
+				null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+		}
 		owner.setJournal(EveKitConverter.convertJournals(journalEntries, owner));
 	}
 

--- a/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitJournalGetter.java
+++ b/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitJournalGetter.java
@@ -20,10 +20,9 @@
  */
 package net.nikr.eve.jeveasset.io.evekit;
 
-
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import enterprises.orbital.evekit.client.invoker.ApiClient;
 import enterprises.orbital.evekit.client.invoker.ApiException;
@@ -41,15 +40,31 @@ public class EveKitJournalGetter extends AbstractEveKitGetter {
 	}
 
 	@Override
-	protected void get(EveKitOwner owner) throws ApiException {
-	  List<WalletJournal> journalEntries = new ArrayList<>();
-		List<WalletJournal> batch = getCommonApi().getJournalEntries(owner.getAccessKey(), owner.getAccessCred(), null, null, Integer.MAX_VALUE, null,
-				null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
-		while (!batch.isEmpty()) {
-		  journalEntries.addAll(batch);
-		  batch = getCommonApi().getJournalEntries(owner.getAccessKey(), owner.getAccessCred(), null, batch.get(batch.size() - 1).getCid(), Integer.MAX_VALUE, null,
-				null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
-		}
+	protected void get(final EveKitOwner owner) throws ApiException {
+	  // Since the journal doesn't change once created, a call to getJournalEntries will return every
+	  // entry ever stored by EveKit since they will all be live at the current time.  So to avoid that we filter
+	  // on the "date" attribute to only get the last two months worth of entries.  We could be smarter here and 
+	  // only get entries after the latest entry we've seen but we'd need to pass that date in.
+	  final long threshold = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(60);
+	  // Page to make sure we get all results
+	  List<WalletJournal> journalEntries = retrievePagedResults(new BatchRetriever<WalletJournal>() {
+
+      @Override
+      public List<WalletJournal> getNextBatch(
+                                              long contid)
+        throws ApiException {
+        return getCommonApi().getJournalEntries(owner.getAccessKey(), owner.getAccessCred(), null, contid, Integer.MAX_VALUE, null,
+                                                null, null, ek_range(threshold, Long.MAX_VALUE), null, null, null, null, null, null, 
+                                                null, null, null, null, null, null);
+      }
+
+      @Override
+      public long getCid(
+                         WalletJournal obj) {
+        return obj.getCid();
+      }
+	    
+	  }); 
 		owner.setJournal(EveKitConverter.convertJournals(journalEntries, owner));
 	}
 

--- a/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitLocationsGetter.java
+++ b/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitLocationsGetter.java
@@ -46,8 +46,25 @@ public class EveKitLocationsGetter extends AbstractEveKitGetter {
 	}
 	
 	@Override
-	protected void get(EveKitOwner owner) throws ApiException {
-		List<Location> locations = getCommonApi().getLocations(owner.getAccessKey(), owner.getAccessCred(), null, null, Integer.MAX_VALUE, null, null, null, null, null, null);
+	protected void get(final EveKitOwner owner) throws ApiException {
+	  // Page to get all location data
+		List<Location> locations = retrievePagedResults(new BatchRetriever<Location>() {
+
+      @Override
+      public List<Location> getNextBatch(
+                                         long contid)
+        throws ApiException {
+        return getCommonApi().getLocations(owner.getAccessKey(), owner.getAccessCred(), null, contid, Integer.MAX_VALUE, null, 
+                                           null, null, null, null, null);
+      }
+
+      @Override
+      public long getCid(
+                         Location obj) {
+        return obj.getCid();
+      }
+		  
+		}); 
 		eveNames.putAll(EveKitConverter.convertLocations(locations));
 	}
 

--- a/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitTransactionsGetter.java
+++ b/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitTransactionsGetter.java
@@ -20,10 +20,9 @@
  */
 package net.nikr.eve.jeveasset.io.evekit;
 
-
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import enterprises.orbital.evekit.client.invoker.ApiClient;
 import enterprises.orbital.evekit.client.invoker.ApiException;
@@ -41,15 +40,31 @@ public class EveKitTransactionsGetter extends AbstractEveKitGetter {
 	}
 
 	@Override
-	protected void get(EveKitOwner owner) throws ApiException {
-	  List<WalletTransaction> walletTransactions = new ArrayList<>();
-	  List<WalletTransaction> batch = getCommonApi().getWalletTransactions(owner.getAccessKey(), owner.getAccessCred(),
-				null, null, Integer.MAX_VALUE, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
-	  while (!batch.isEmpty()) {
-	    walletTransactions.addAll(batch);
-	    batch = getCommonApi().getWalletTransactions(owner.getAccessKey(), owner.getAccessCred(),
-				null, batch.get(batch.size() - 1).getCid(), Integer.MAX_VALUE, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
-	  }
+	protected void get(final EveKitOwner owner) throws ApiException {
+	  // Since wallet transactions never change once created, a call to getWalletTransactions will return every
+	  // transaction ever stored by EveKit since they will all be live at the current time.  So to avoid that we filter
+	  // on the "date" attribute to only get the last two months worth of transactions.  We could be smarter here and 
+	  // only get transactions after the latest transaction we've seen but we'd need to pass that date in.
+	  final long threshold = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(60);
+	  // Page to make sure we get all results
+	  List<WalletTransaction> walletTransactions = retrievePagedResults(new BatchRetriever<WalletTransaction>() {
+
+      @Override
+      public List<WalletTransaction> getNextBatch(
+                                                  long contid)
+        throws ApiException {
+        return getCommonApi().getWalletTransactions(owner.getAccessKey(), owner.getAccessCred(), null, contid, Integer.MAX_VALUE, 
+                                                    null, null, null, ek_range(threshold, Long.MAX_VALUE), null, null, null, null, 
+                                                    null, null, null, null, null, null, null, null, null, null);
+      }
+
+      @Override
+      public long getCid(
+                         WalletTransaction obj) {
+        return obj.getCid();
+      }
+	    
+	  });
 		owner.setTransactions(EveKitConverter.convertTransactions(walletTransactions, owner));
 	}
 

--- a/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitTransactionsGetter.java
+++ b/src/main/java/net/nikr/eve/jeveasset/io/evekit/EveKitTransactionsGetter.java
@@ -21,11 +21,13 @@
 package net.nikr.eve.jeveasset.io.evekit;
 
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 import enterprises.orbital.evekit.client.invoker.ApiClient;
 import enterprises.orbital.evekit.client.invoker.ApiException;
 import enterprises.orbital.evekit.client.model.WalletTransaction;
-import java.util.Date;
-import java.util.List;
 import net.nikr.eve.jeveasset.data.evekit.EveKitAccessMask;
 import net.nikr.eve.jeveasset.data.evekit.EveKitOwner;
 import net.nikr.eve.jeveasset.gui.dialogs.update.UpdateTask;
@@ -40,8 +42,14 @@ public class EveKitTransactionsGetter extends AbstractEveKitGetter {
 
 	@Override
 	protected void get(EveKitOwner owner) throws ApiException {
-		List<WalletTransaction> walletTransactions = getCommonApi().getWalletTransactions(owner.getAccessKey(), owner.getAccessCred(),
+	  List<WalletTransaction> walletTransactions = new ArrayList<>();
+	  List<WalletTransaction> batch = getCommonApi().getWalletTransactions(owner.getAccessKey(), owner.getAccessCred(),
 				null, null, Integer.MAX_VALUE, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+	  while (!batch.isEmpty()) {
+	    walletTransactions.addAll(batch);
+	    batch = getCommonApi().getWalletTransactions(owner.getAccessKey(), owner.getAccessCred(),
+				null, batch.get(batch.size() - 1).getCid(), Integer.MAX_VALUE, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+	  }
 		owner.setTransactions(EveKitConverter.convertTransactions(walletTransactions, owner));
 	}
 


### PR DESCRIPTION
This is a sample PR showing how to page in results from EveKit, you may not want to merge this.  As is, with this change the entire set of market orders and wallet entries will be pulled in every time you update.  That will be too much after a few weeks on an active account.  Anyway...

Right now, each EveKit request will return at most 1000 results.  Results are ordered increasing by "cached id" which is retrievable with the getCid() call on returned objects.  The examples below just iterate using cid until no more results are returned.  You can iterate from most recent instead by setting the "reverse" flag, and initializing cid to Long.MAX_VALUE.  Here's an example for market orders:

// Get newest entries first, returned in descending order by cid
List<MarketOrder> nextOrders = getCommonApi().getMarketOrders(owner.getAccessKey(), owner.getAccessCred(), null, Long.MAX_VALUE, Integer.MAX_VALUE, true, null, null,
                                                                  null, null, null, null, null, null, null, null, null, null, null, null, null);
