### PR TITLE
Bug Fix: Market order outbid has was never being cleared of old entri…

### DIFF
--- a/src/main/java/net/nikr/eve/jeveasset/data/settings/Settings.java
+++ b/src/main/java/net/nikr/eve/jeveasset/data/settings/Settings.java
@@ -564,6 +564,7 @@ public class Settings {
 	}
 
 	public void setMarketOrdersOutbid(Map<Long, Outbid> outbids) {
+		marketOrdersOutbid.clear();
 		marketOrdersOutbid.putAll(outbids);
 	}
 


### PR DESCRIPTION
Old entries in outbid hash map were not being cleaned up. This would cause old outbids to show up under some circumstances. Clearing the hash before add new entries fixes the issue. (Issue #239)