### PR TITLE
Fix Issue #366 - Use correct amounts when creating new stockpiles fro…

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -35,6 +35,7 @@ Contributors:
   Inoruuk
   Burberius
   Lazaren
+  Boran Lordsworth
 
 Retired Testers:
   Varo Jan

--- a/src/main/java/net/nikr/eve/jeveasset/gui/dialogs/AboutDialog.java
+++ b/src/main/java/net/nikr/eve/jeveasset/gui/dialogs/AboutDialog.java
@@ -106,6 +106,7 @@ public class AboutDialog extends JDialogCentered {
 				+ "&nbsp;Inoruuk<br>"
 				+ "&nbsp;Burberius<br>"
 				+ "&nbsp;Lazaren<br>"
+				+ "&nbsp;Boran Lordsworth<br>"
 				+ "<br>"
 				+ "<b>Retired Testers</b><br>"
 				+ "&nbsp;Varo Jan<br>"

--- a/src/main/java/net/nikr/eve/jeveasset/gui/shared/menu/JMenuStockpile.java
+++ b/src/main/java/net/nikr/eve/jeveasset/gui/shared/menu/JMenuStockpile.java
@@ -147,7 +147,7 @@ public class JMenuStockpile<T> extends JAutoMenu<T> {
 								items.add(new StockpileItem(stockpile, materialItem, material.getTypeID(), material.getQuantity(), false));
 							}
 						} else { //source or not bluepint/formula
-							items.add(new StockpileItem(stockpile, item, typeID, DEFAULT_ADD_COUNT, false));
+							items.add(new StockpileItem(stockpile, item, typeID, menuData.getItemCounts().getOrDefault(item, 1L), false));
 						}
 					}
 					stockpile = program.getStockpileTab().addToStockpile(stockpile, items);


### PR DESCRIPTION
Implement Feature Request #366 . Stockpiles created from other tabs in jEveAssets (e.g. Contracts, Fittings, etc...) will now use the correct amounts from the originating tab.