### PR TITLE
Fix #413

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -39,6 +39,7 @@ Contributors:
   Burberius
   Lazaren
   Boran Lordsworth
+  Ed Thelleres
 
 Retired Testers:
   Varo Jan

--- a/src/main/java/net/nikr/eve/jeveasset/gui/dialogs/AboutDialog.java
+++ b/src/main/java/net/nikr/eve/jeveasset/gui/dialogs/AboutDialog.java
@@ -111,6 +111,7 @@ public class AboutDialog extends JDialogCentered {
 				+ "&nbsp;Burberius<br>"
 				+ "&nbsp;Lazaren<br>"
 				+ "&nbsp;Boran Lordsworth<br>"
+				+ "&nbsp;Ed Thelleres<br>"
 				+ "<br>"
 				+ "<b>Retired Testers</b><br>"
 				+ "&nbsp;Varo Jan<br>"

--- a/src/main/java/net/nikr/eve/jeveasset/io/shared/ApiIdConverter.java
+++ b/src/main/java/net/nikr/eve/jeveasset/io/shared/ApiIdConverter.java
@@ -383,9 +383,8 @@ public final class ApiIdConverter {
 	}
 
 	private static double roundManufacturingQuantity(double manufacturingQuantity, double runs) {
-		//max(runs,ceil(round((base * ((100-ME)/100) * (EC modifier) * (EC Rig modifier))*runs,2)))
-		return Math.max(runs, Math.ceil(roundQuantity(manufacturingQuantity, 2)) * runs);
-	}
+		//max(runs,round(ceil((base * ((100-ME)/100) * (EC modifier) * (EC Rig modifier))*runs,2)))
+		return Math.max(runs, roundQuantity(manufacturingQuantity, 6) * runs);	}
 
 	private static double percentToBonus(double value) {
 		return ((100.0 - value) / 100.0);
@@ -401,7 +400,7 @@ public final class ApiIdConverter {
 
 	private static double roundQuantity(double value, int places) {
 		double scale = Math.pow(10, places);
-		return Math.round(value * scale) / scale;
+		return Math.ceil(value * scale) / scale;
 	}
 
 	public static double getPriceReprocessed(Item item) {


### PR DESCRIPTION
fix for issue #413

roundQuantity() does the rounding to two decimal places and returns correctly, but is immediately ceiled in the caller method roundManufacturingQuantity(). I removed the ceil in the caller method and moved it to roundQuantity() instead of Math.round(). Precision was increased to 6 digits in order to preserve precision for multiplying the stokpile.
