### PR TITLE
Feature/reaction calculations

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -39,6 +39,7 @@ Contributors:
   Burberius
   Lazaren
   Boran Lordsworth
+  Ed Thelleres
 
 Retired Testers:
   Varo Jan

--- a/src/main/java/net/nikr/eve/jeveasset/data/settings/ManufacturingSettings.java
+++ b/src/main/java/net/nikr/eve/jeveasset/data/settings/ManufacturingSettings.java
@@ -127,6 +127,49 @@ public class ManufacturingSettings {
 		}
 	}
 
+	public static enum ReactionRigs {
+		NONE(0) {
+			@Override
+			public String getText() {
+				return DialoguesSettings.get().manufacturingRigsNone();
+			}
+		},
+		T1(2.0) {
+			@Override
+			public String getText() {
+				return DialoguesSettings.get().manufacturingRigsT1();
+			}
+		},
+		T2(2.40) {
+			@Override
+			public String getText() {
+				return DialoguesSettings.get().manufacturingRigsT2();
+			}
+		};
+
+		private final double materialBonus;
+
+		private ReactionRigs(double materialBonus) {
+			this.materialBonus = materialBonus;
+		}
+
+		public abstract String getText();
+
+		@Override
+		public String toString() {
+			return getText();
+			//return getText() + " (" + materialBonus + "%)";
+		}
+
+		public double getMaterialBonus() {
+			return materialBonus;
+		}
+
+		public static ReactionRigs getDefault() {
+			return NONE;
+		}
+	}
+
 	public static enum ManufacturingSecurity {
 		HIGHSEC(1) {
 			@Override
@@ -167,6 +210,43 @@ public class ManufacturingSettings {
 
 		public static ManufacturingSecurity getDefault() {
 			return HIGHSEC;
+		}
+	}
+
+	public static enum ReactionSecurity {
+		LOWSEC(1.0) {
+			@Override
+			public String getText() {
+				return DialoguesSettings.get().manufacturingSecurityLowSec();
+			}
+		},
+		NULLSEC(1.1) {
+			@Override
+			public String getText() {
+				return DialoguesSettings.get().manufacturingSecurityNullSec();
+			}
+		};
+
+		private final double rigBonus;
+
+		private ReactionSecurity(double rigBonus) {
+			this.rigBonus = rigBonus;
+		}
+
+		public abstract String getText();
+
+		public double getRigBonus() {
+			return rigBonus;
+		}
+
+		@Override
+		public String toString() {
+			return getText();
+			//return getText() + " (" + rigBonus + "%)";
+		}
+
+		public static ReactionSecurity getDefault() {
+			return LOWSEC;
 		}
 	}
 

--- a/src/main/java/net/nikr/eve/jeveasset/gui/dialogs/AboutDialog.java
+++ b/src/main/java/net/nikr/eve/jeveasset/gui/dialogs/AboutDialog.java
@@ -111,6 +111,7 @@ public class AboutDialog extends JDialogCentered {
 				+ "&nbsp;Burberius<br>"
 				+ "&nbsp;Lazaren<br>"
 				+ "&nbsp;Boran Lordsworth<br>"
+				+ "&nbsp;Ed Thelleres<br>"
 				+ "<br>"
 				+ "<b>Retired Testers</b><br>"
 				+ "&nbsp;Varo Jan<br>"

--- a/src/main/java/net/nikr/eve/jeveasset/gui/tabs/stockpile/StockpileItemDialog.java
+++ b/src/main/java/net/nikr/eve/jeveasset/gui/tabs/stockpile/StockpileItemDialog.java
@@ -52,7 +52,9 @@ import net.nikr.eve.jeveasset.data.settings.ColorSettings;
 import net.nikr.eve.jeveasset.data.settings.ManufacturingSettings;
 import net.nikr.eve.jeveasset.data.settings.ManufacturingSettings.ManufacturingFacility;
 import net.nikr.eve.jeveasset.data.settings.ManufacturingSettings.ManufacturingRigs;
+import net.nikr.eve.jeveasset.data.settings.ManufacturingSettings.ReactionRigs;
 import net.nikr.eve.jeveasset.data.settings.ManufacturingSettings.ManufacturingSecurity;
+import net.nikr.eve.jeveasset.data.settings.ManufacturingSettings.ReactionSecurity;
 import net.nikr.eve.jeveasset.data.settings.Settings;
 import net.nikr.eve.jeveasset.gui.images.Images;
 import net.nikr.eve.jeveasset.gui.shared.components.JDialogCentered;
@@ -108,11 +110,14 @@ public class StockpileItemDialog extends JDialogCentered {
 	private final JComboBox<Integer> jMe;
 	private final JComboBox<ManufacturingFacility> jFacility;
 	private final JComboBox<ManufacturingRigs> jRigs;
+	private final JComboBox<ReactionRigs> jRigsReactions;
 	private final JComboBox<ManufacturingSecurity> jSecurity;
+	private final JComboBox<ReactionSecurity> jSecurityReactions;
 	private final JLabel jIgnoreMultiplierLabel;
 	private final JCheckBox jIgnoreMultiplier;
 
 	private final List<JComponent> manufacturingComponents = new ArrayList<>();
+	private final List<JComponent> reactionComponents = new ArrayList<>();
 	private final EventList<Item> items = EventListManager.create();
 	private Stockpile stockpile;
 	private StockpileItem stockpileItem;
@@ -193,10 +198,34 @@ public class StockpileItemDialog extends JDialogCentered {
 		});
 		manufacturingComponents.add(jRigs);
 
+		JLabel jRigsReactionsLabel = new JLabel(TabsStockpile.get().blueprintRigs());
+		reactionComponents.add(jRigsReactionsLabel);
+		jRigsReactions = new JComboBox<>(ReactionRigs.values());
+		jRigsReactions.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				ReactionRigs rigs = jRigsReactions.getItemAt(jRigsReactions.getSelectedIndex());
+				if (rigs == ReactionRigs.NONE) {
+					jSecurityReactions.setSelectedIndex(0);
+					jSecurityReactions.setEnabled(false);
+				} else {
+					jSecurityReactions.setEnabled(true);
+				}
+			}
+		});
+		reactionComponents.add(jRigsReactions);
+
+
 		JLabel jSecurityLabel = new JLabel(TabsStockpile.get().blueprintSecurity());
 		manufacturingComponents.add(jSecurityLabel);
 		jSecurity = new JComboBox<>(ManufacturingSecurity.values());
 		manufacturingComponents.add(jSecurity);
+
+		JLabel jSecurityReactionsLabel = new JLabel(TabsStockpile.get().blueprintSecurity());
+		reactionComponents.add(jSecurityReactionsLabel);
+		jSecurityReactions = new JComboBox<>(ReactionSecurity.values());
+		reactionComponents.add(jSecurityReactions);
+
 
 		jOK = new JButton(TabsStockpile.get().ok());
 		jOK.setActionCommand(StockpileItemAction.OK.name());
@@ -216,7 +245,9 @@ public class StockpileItemDialog extends JDialogCentered {
 						.addComponent(jMeLabel)
 						.addComponent(jFacilityLabel)
 						.addComponent(jRigsLabel)
+						.addComponent(jRigsReactionsLabel)
 						.addComponent(jSecurityLabel)
+						.addComponent(jSecurityReactionsLabel)
 						.addComponent(jIgnoreMultiplierLabel)
 						.addComponent(jCountMinimumLabel)
 					)
@@ -227,7 +258,9 @@ public class StockpileItemDialog extends JDialogCentered {
 						.addComponent(jMe, 300, 300, 300)
 						.addComponent(jFacility, 300, 300, 300)
 						.addComponent(jRigs, 300, 300, 300)
+						.addComponent(jRigsReactions, 300, 300, 300)
 						.addComponent(jSecurity, 300, 300, 300)
+						.addComponent(jSecurityReactions, 300, 300, 300)
 						.addComponent(jIgnoreMultiplier, 300, 300, 300)
 						.addComponent(jCountMinimum, 300, 300, 300)
 					)
@@ -261,8 +294,16 @@ public class StockpileItemDialog extends JDialogCentered {
 					.addComponent(jRigs, Program.getButtonsHeight(), Program.getButtonsHeight(), Program.getButtonsHeight())
 				)
 				.addGroup(layout.createParallelGroup()
+						.addComponent(jRigsReactionsLabel, Program.getButtonsHeight(), Program.getButtonsHeight(), Program.getButtonsHeight())
+						.addComponent(jRigsReactions, Program.getButtonsHeight(), Program.getButtonsHeight(), Program.getButtonsHeight())
+				)
+				.addGroup(layout.createParallelGroup()
 					.addComponent(jSecurityLabel, Program.getButtonsHeight(), Program.getButtonsHeight(), Program.getButtonsHeight())
 					.addComponent(jSecurity, Program.getButtonsHeight(), Program.getButtonsHeight(), Program.getButtonsHeight())
+				)
+				.addGroup(layout.createParallelGroup()
+						.addComponent(jSecurityReactionsLabel, Program.getButtonsHeight(), Program.getButtonsHeight(), Program.getButtonsHeight())
+						.addComponent(jSecurityReactions, Program.getButtonsHeight(), Program.getButtonsHeight(), Program.getButtonsHeight())
 				)
 				.addGroup(layout.createParallelGroup()
 					.addComponent(jIgnoreMultiplierLabel, Program.getButtonsHeight(), Program.getButtonsHeight(), Program.getButtonsHeight())
@@ -405,7 +446,9 @@ public class StockpileItemDialog extends JDialogCentered {
 		Integer me = jMe.getItemAt(jMe.getSelectedIndex());
 		ManufacturingFacility facility = jFacility.getItemAt(jFacility.getSelectedIndex());
 		ManufacturingRigs rigs = jRigs.getItemAt(jRigs.getSelectedIndex());
+		ReactionRigs rigsReactions = jRigsReactions.getItemAt(jRigsReactions.getSelectedIndex());
 		ManufacturingSecurity security = jSecurity.getItemAt(jSecurity.getSelectedIndex());
+		ReactionSecurity securityReactions = jSecurityReactions.getItemAt(jSecurityReactions.getSelectedIndex());
 		if (jBlueprintType.isEnabled() && jBlueprintType.getItemAt(jBlueprintType.getSelectedIndex()) == BlueprintAddType.MANUFACTURING_MATERIALS) {
 			 //Manufacturing Materials
 			for (IndustryMaterial material : item.getManufacturingMaterials()) {
@@ -417,7 +460,7 @@ public class StockpileItemDialog extends JDialogCentered {
 			//Reaction Materials
 			for (IndustryMaterial material : item.getReactionMaterials()) {
 				Item materialItem = ApiIdConverter.getItem(material.getTypeID());
-				double count = ApiIdConverter.getManufacturingQuantity(material.getQuantity(), me, facility, rigs, security, countMinimum, false);
+				double count = ApiIdConverter.getReactionQuantity(material.getQuantity(), rigsReactions, securityReactions, countMinimum, false);
 				itemsMaterial.add(new StockpileItem(getStockpile(), materialItem, material.getTypeID(), count, false, ignoreMultiplier));
 			}
 		} else {
@@ -619,17 +662,47 @@ public class StockpileItemDialog extends JDialogCentered {
 				autoSet();
 				autoValidate();
 				BlueprintAddType currentBlueprintAddType = jBlueprintType.getItemAt(jBlueprintType.getSelectedIndex());
-				if ((lastBlueprintAddType == null || lastBlueprintAddType != BlueprintAddType.MANUFACTURING_MATERIALS) && jBlueprintType.isEnabled() && currentBlueprintAddType == BlueprintAddType.MANUFACTURING_MATERIALS) {
-					for (JComponent jComponent : manufacturingComponents) {
-						jComponent.setVisible(true);
+				if (lastBlueprintAddType != currentBlueprintAddType) {
+					if (lastBlueprintAddType == null) {
+						for (JComponent jComponent : manufacturingComponents) {
+							jComponent.setVisible(false);
+						}
+						for (JComponent jComponent : reactionComponents) {
+							jComponent.setVisible(false);
+						}
+					} else {
+						switch (lastBlueprintAddType) {
+							case MANUFACTURING_MATERIALS:
+								for (JComponent jComponent : manufacturingComponents) {
+									jComponent.setVisible(false);
+								}
+								break;
+							case REACTION_MATERIALS:
+								for (JComponent jComponent : reactionComponents) {
+									jComponent.setVisible(false);
+								}
+								break;
+						}
 					}
-					jMe.setSelectedIndex(0);
-					jFacility.setSelectedIndex(0);
-					jRigs.setSelectedIndex(0);
-					getDialog().pack();
-				} else if ((lastBlueprintAddType == null || lastBlueprintAddType == BlueprintAddType.MANUFACTURING_MATERIALS) && currentBlueprintAddType != BlueprintAddType.MANUFACTURING_MATERIALS) {
-					for (JComponent jComponent : manufacturingComponents) {
-						jComponent.setVisible(false);
+					if (jBlueprintType.isEnabled()) {
+						switch (currentBlueprintAddType) {
+							case MANUFACTURING_MATERIALS:
+								for (JComponent jComponent : manufacturingComponents) {
+									jComponent.setVisible(true);
+								}
+								jMe.setSelectedIndex(0);
+								jFacility.setSelectedIndex(0);
+								jRigs.setSelectedIndex(0);
+								break;
+							case REACTION_MATERIALS:
+								for (JComponent jComponent : reactionComponents) {
+									jComponent.setVisible(true);
+									jComponent.setEnabled(true);
+								}
+								jRigsReactions.setSelectedIndex(0);
+								jRigsReactions.setEnabled(true);
+								break;
+						}
 					}
 					getDialog().pack();
 				}

--- a/src/main/java/net/nikr/eve/jeveasset/io/shared/ApiIdConverter.java
+++ b/src/main/java/net/nikr/eve/jeveasset/io/shared/ApiIdConverter.java
@@ -47,7 +47,9 @@ import net.nikr.eve.jeveasset.data.settings.Citadel.CitadelSource;
 import net.nikr.eve.jeveasset.data.settings.ManufacturingSettings;
 import net.nikr.eve.jeveasset.data.settings.ManufacturingSettings.ManufacturingFacility;
 import net.nikr.eve.jeveasset.data.settings.ManufacturingSettings.ManufacturingRigs;
+import net.nikr.eve.jeveasset.data.settings.ManufacturingSettings.ReactionRigs;
 import net.nikr.eve.jeveasset.data.settings.ManufacturingSettings.ManufacturingSecurity;
+import net.nikr.eve.jeveasset.data.settings.ManufacturingSettings.ReactionSecurity;
 import net.nikr.eve.jeveasset.data.settings.PriceData;
 import net.nikr.eve.jeveasset.data.settings.ReprocessSettings;
 import net.nikr.eve.jeveasset.data.settings.Settings;
@@ -383,6 +385,10 @@ public final class ApiIdConverter {
 		return roundManufacturingQuantity(quantity * percentToBonus(me) * percentToBonus(facility.getMaterialBonus()) * rigToBonus(rigs, security), runs, round);
 	}
 
+	public static double getReactionQuantity(int quantity, ManufacturingSettings.ReactionRigs rigs, ManufacturingSettings.ReactionSecurity security, double runs, boolean round) {
+		return roundManufacturingQuantity(quantity * rigToBonus(rigs, security), runs, round);
+	}
+
 	private static double roundManufacturingQuantity(double manufacturingQuantity, double runs, boolean round) {
 		//max(runs,round(ceil((base * ((100-ME)/100) * (EC modifier) * (EC Rig modifier))*runs,2)))
 		double quantity = Math.max(runs, roundQuantity(manufacturingQuantity, 2) * runs);
@@ -399,6 +405,14 @@ public final class ApiIdConverter {
 
 	private static double rigToBonus(ManufacturingRigs rigs, ManufacturingSecurity security) {
 		if (rigs == ManufacturingRigs.NONE) {
+			return 1;
+		} else {
+			return percentToBonus(rigs.getMaterialBonus() * security.getRigBonus());
+		}
+	}
+
+	private static double rigToBonus(ReactionRigs rigs, ReactionSecurity security) {
+		if (rigs == ReactionRigs.NONE) {
 			return 1;
 		} else {
 			return percentToBonus(rigs.getMaterialBonus() * security.getRigBonus());


### PR DESCRIPTION
This PR aims to fix a missing calculation for reactions.

Compared to regular manufacturing, reactions are limited to LS or NS space and refinery type structures. Material Efficiency is reduced only by using structure rigs. T1 rig gives 2% and T2 gives 2.4% (same as manufacturing). The real difference comes from the bonus applied to the rig based on the system's security. Low sec gives 1.0 modifier (no bonus) and nullsec gives 1.1 (+10%).

In the current version of the program, reaction materials are computed using manufacturing logic and at the same time it's not possible to set a rig / system security for reactions. That results in having unbonused reactions in stockpiles (or at least in the past having them bonused at ~15%).

Rounding is still kept at 2 decimal points (as it uses the same method), but I recommend bumping that up to 5 places (see #426 ).

I've decided to duplicate ManufacturingRigs even though ReactionRigs are identical as it feels like it should be separate pieces of code. Handling of the StockpileItemDialog is not pretty but works.

Tested with JDK8 and JDK17 on macOS Sonoma (M2 Apple Silicon)