### PR TITLE
keep original name when cloning stockpiles

### DIFF
--- a/src/main/java/net/nikr/eve/jeveasset/gui/tabs/stockpile/StockpileDialog.java
+++ b/src/main/java/net/nikr/eve/jeveasset/gui/tabs/stockpile/StockpileDialog.java
@@ -400,7 +400,7 @@ public class StockpileDialog extends JDialogCentered {
 		//Title
 		this.getDialog().setTitle(TabsStockpile.get().cloneStockpileTitle());
 		//Load
-		loadStockpile(cloneStockpile, "");
+		loadStockpile(cloneStockpile, stockpile.getName());
 		//Show
 		show();
 		if (updated) {


### PR DESCRIPTION
When cloning stockpiles, we can expect the user might want to keep a similar name to the original rather than give a completely new name. This change saves time and nerves when you have to retype the original name all over again just to add 2 at the end.

The name input is preselected when cloning, i.e. if you want a completely new name, it's enough to just hit the delete key.