### PR TITLE
Add desktop entry and AppStream metadata for Linux

### DIFF
--- a/tools/io.github.GoldenGnu.jEveAssets.desktop
+++ b/tools/io.github.GoldenGnu.jEveAssets.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Terminal=false
+Name=jEveAssets
+Exec=java -jar /opt/jEveAssets/jeveassets.jar
+Comment=Asset manager for EVE Online
+Icon=io.github.GoldenGnu.jEveAssets
+Categories=Game;

--- a/tools/io.github.GoldenGnu.jEveAssets.metainfo.xml
+++ b/tools/io.github.GoldenGnu.jEveAssets.metainfo.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+    <id>io.github.GoldenGnu.jEveAssets</id>
+    <launchable type="desktop-id">io.github.GoldenGnu.jEveAssets.desktop</launchable>
+    <name>jEveAssets</name>
+    <developer_name>GoldenGnu</developer_name>
+    <summary>jEveAssets is an out-of-game asset manager for Eve-Online</summary>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>GPL-2.0-only</project_license>
+    <url type="homepage">https://github.com/GoldenGnu/jeveassets</url>
+    <categories>
+        <category>Game</category>
+    </categories>
+    <description>
+        <p>
+            jEveAssets is an out-of-game asset manager for Eve-Online, written in Java.
+        </p>
+        <p>
+            EVE Online and the EVE logo are the registered trademarks of CCP hf. All rights are reserved worldwide. All
+            other trademarks are the property of their respective owners. EVE Online, the EVE logo, EVE and all
+            associated logos and designs are the intellectual property of CCP hf. All artwork, screenshots, characters,
+            vehicles, storylines, world facts or other recognizable features of the intellectual property relating to
+            these trademarks are likewise the intellectual property of CCP hf.
+        </p>
+        <p>
+            CCP hf. has granted permission to jEveAssets to use EVE Online and all associated logos and designs for
+            promotional and information purposes on its website but does not endorse, and is not in any way affiliated
+            with, jEveAssets. CCP is in no way responsible for the content on or functioning of this program, nor can it
+            be liable for any damage arising from the use of this program.
+        </p>
+    </description>
+    <screenshots>
+        <screenshot type="default">
+            <image>https://eve.nikr.net/jeveassets/default.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://eve.nikr.net/jeveassets/tree.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://eve.nikr.net/jeveassets/values.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://eve.nikr.net/jeveassets/isk.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://eve.nikr.net/jeveassets/tracker.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://eve.nikr.net/jeveassets/mininggraph.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://eve.nikr.net/jeveassets/mininglog%20.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://eve.nikr.net/jeveassets/items.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://eve.nikr.net/jeveassets/materials.png</image>
+        </screenshot>
+    </screenshots>
+    <releases>
+        <release version="7.8.1" date="2023-10-18">
+            <description>
+                <p>
+                    <strong>Bug Fixes:</strong>
+                    -Removed outbid auto-update due to impact on esi
+
+                    -Added advanced contracting to the slots tool (Reported by MagnarM)
+                </p>
+                <p>
+                    <strong>Statement regarding removing features:</strong>
+
+                    jEveAssets outbid auto update had a negative impact on ESI (and thereby Eve) - that is not
+                    acceptable! ESI is a shared resource and that means everyone who use it have to use it responsible.
+                    In this case the means I had to remove the functionality from jEveAssets, which isn't something I
+                    like doing, but, it had to be done to be a good esi citizen, which is absolutely required.
+                </p>
+            </description>
+        </release>
+    </releases>
+    <content_rating type="oars-1.1"/>
+</component>
+


### PR DESCRIPTION
These changes introduce two new files under /tools to assist in Linux packaging:

* The dekstop entry file can be used as a sample template for launching jEvEAssets through double clicking a desktop shortcut instead of the [command line](https://wiki.jeveassets.org/faq?s[]=linux#linux1).
* The [AppStream metadata](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent) file describes the application for software centers on Linux (Discover, Flathub, etc.)
