### PR TITLE
feat: Automatic naming for loadout EFT export

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -675,6 +675,18 @@
 			</properties>
 		</profile>
 		<profile>
+		    <id>skip-all-tests</id>
+		    <activation>
+			<property>
+			    <name>skip-all-tests</name>
+			    <value>true</value>
+			</property>
+		    </activation>
+		    <properties>
+			<maven.test.skip>true</maven.test.skip>
+		    </properties>
+		</profile>
+		<profile>
 			<id>skip-online-price-tests</id>
 			<activation>
 				<property>

--- a/src/main/java/net/nikr/eve/jeveasset/gui/tabs/loadout/LoadoutsTab.java
+++ b/src/main/java/net/nikr/eve/jeveasset/gui/tabs/loadout/LoadoutsTab.java
@@ -375,7 +375,7 @@ public class LoadoutsTab extends JMainTabSecondary {
 		if (exportAsset == null) {
 			return;
 		}
-		String buildName = getBuildName();
+		String buildName = getBuildName(exportAsset.getName());
 		if (buildName == null) {
 			return; //Cancel
 		}
@@ -459,8 +459,9 @@ public class LoadoutsTab extends JMainTabSecondary {
 		}
 	}
 
-	private String getBuildName() {
-		String buildName = JOptionInput.showInputDialog(program.getMainWindow().getFrame(), "Enter Build Name", "Export EFT", JOptionPane.PLAIN_MESSAGE);
+	private String getBuildName(String shipName) {
+		String defaultName = shipName.replaceFirst("\\s*\\([^)]*\\)\\s*$", "");
+		String buildName = (String) JOptionInput.showInputDialog(program.getMainWindow().getFrame(), "Enter Build Name", "Export EFT", JOptionPane.PLAIN_MESSAGE, null, null, defaultName);
 		if (buildName == null) {
 			return null; //Cancel
 		} else if (buildName.isEmpty()) {
@@ -468,7 +469,7 @@ public class LoadoutsTab extends JMainTabSecondary {
 					TabsLoadout.get().name1(),
 					TabsLoadout.get().empty(),
 					JOptionPane.PLAIN_MESSAGE);
-			return getBuildName();
+			return getBuildName(defaultName);
 		} else {
 			return buildName;
 		}


### PR DESCRIPTION
Uses the asset name of the ship to pre-populate the loadout name field when exporting through EFT.

fixes #471 