### PR TITLE
New Feature: Add CLI ESI authorization refresh (Issue #540)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,18 @@ Link:
   https://wiki.jeveassets.org/faq
 
 ________________________________________________________________________________
+_COMMAND LINE___________________________________________________________________
+
+Refresh all stored ESI authorizations without updating ESI data:
+
+  java "-Djava.awt.headless=true" -jar jeveassets.jar -r
+
+Use -refresh for the long option. The command uses all profiles belonging to
+the current operating-system user. No other jEveAssets instance can be running.
+Exit status: 0 success, 1 profile or authorization failure, 2 local data
+preparation or save failure, and 64 invalid options.
+
+________________________________________________________________________________
 _CONTACT________________________________________________________________________
 
 www:

--- a/src/main/java/net/nikr/eve/jeveasset/CliOptions.java
+++ b/src/main/java/net/nikr/eve/jeveasset/CliOptions.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.nikr.eve.jeveasset.CliExport.ExportTool;
 import net.nikr.eve.jeveasset.data.settings.ExportSettings;
@@ -48,11 +47,13 @@ import picocli.CommandLine.PicocliException;
 
 @Command(sortOptions = false,
 		synopsisHeading = "",
-		customSynopsis = "Usage: java [-Djava.awt.headless=true] -jar jeveassets.jar [-h] [-v] [-p] [-z] [-u] [-e [OPTIONS]]",
+		customSynopsis = "Usage: java [\"-Djava.awt.headless=true\"] -jar jeveassets.jar [-h] [-v] [-p] [-z] [[-u] [-e [OPTIONS]] | -r]",
 		description="%n  -Djava.awt.headless=true   Run without a GUI%n"
 				+ "                             Java parameter (must be specified before -jar)"
 		)
 public class CliOptions {
+
+	private static final int EXIT_USAGE = 64;
 
 	private static final Logger LOG = Logger.getLogger(CliOptions.class.getName());
 
@@ -99,10 +100,10 @@ public class CliOptions {
 	public static CommandLine set(final String[] args) {
 		CommandLine cmd = new CommandLine(CLI_OPTIONS);
 		try {
-			cmd.parseArgs(args);
-		} catch (PicocliException ex) {
-			LOG.log(Level.SEVERE, ex.getMessage(), ex);
-			System.exit(-1);
+			cmd = CLI_OPTIONS.parse(args);
+		} catch (PicocliException ignored) {
+			LOG.severe("Invalid command line options");
+			System.exit(EXIT_USAGE);
 		}
 		if (CLI_OPTIONS.help) {
 			cmd.setUsageHelpWidth(110);
@@ -113,6 +114,15 @@ public class CliOptions {
 		if (CLI_OPTIONS.version) {
 			System.out.println(Program.PROGRAM_NAME + " " + Program.PROGRAM_VERSION);
 			System.exit(0);
+		}
+		return cmd;
+	}
+
+	CommandLine parse(final String[] args) {
+		CommandLine cmd = new CommandLine(this);
+		cmd.parseArgs(args);
+		if (isRefresh() && isExport()) {
+			throw new CommandLine.ParameterException(cmd, "Refresh can not be combined with export options");
 		}
 		return cmd;
 	}
@@ -128,12 +138,14 @@ public class CliOptions {
 			+ "    This may cause you to lose data if jEveAssets exit unexpectedly" + END_GROUP)
 	boolean lazySave;
 
-	@ArgGroup(exclusive = false, heading = "Update Options:%n")
+	@ArgGroup(exclusive = true, heading = "Update Options:%n")
 	UpdateOptions updateOptions;
 
 	static class UpdateOptions {
 		@Option(names = { "-u", "-update"}, required = true, description = "Update Data%nUpdate all profiles and accounts%nAll data with cache expired will be updated" + END_GROUP)
 		boolean update;
+		@Option(names = { "-r", "-refresh"}, required = true, description = "Refresh ESI authorization%nRefresh all profiles and accounts%nNo ESI data will be updated%nThe GUI must be closed" + END_GROUP)
+		boolean refresh;
 	}
 
 	@ArgGroup(exclusive = false, heading = "Export Options:%n")
@@ -627,8 +639,15 @@ public class CliOptions {
 		return updateOptions.update;
 	}
 
+	public boolean isRefresh() {
+		if (updateOptions == null) {
+			return false;
+		}
+		return updateOptions.refresh;
+	}
+
 	public boolean isCLI() {
-		return isUpdate() || isExport();
+		return isUpdate() || isRefresh() || isExport();
 	}
 
 	public boolean isExport() {

--- a/src/main/java/net/nikr/eve/jeveasset/CliRefresh.java
+++ b/src/main/java/net/nikr/eve/jeveasset/CliRefresh.java
@@ -1,0 +1,544 @@
+/*
+ * Copyright 2009-2026 Contributors (see credits.txt)
+ *
+ * This file is part of jEveAssets.
+ *
+ * jEveAssets is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * jEveAssets is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jEveAssets; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package net.nikr.eve.jeveasset;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import net.nikr.eve.jeveasset.data.api.accounts.EsiOwner;
+import net.nikr.eve.jeveasset.data.profile.Profile;
+import net.nikr.eve.jeveasset.data.profile.ProfileManager;
+import net.nikr.eve.jeveasset.io.esi.EsiCallbackURL;
+import net.nikr.eve.jeveasset.io.local.profile.ProfileDatabase.Table;
+import net.troja.eve.esi.ApiClientBuilder;
+import net.troja.eve.esi.auth.OAuth;
+
+
+public class CliRefresh {
+
+	static final int EXIT_AUTHORIZATION_FAILURE = 1;
+	static final int EXIT_PERSISTENCE_FAILURE = 2;
+
+	private final ProfileStore profileStore;
+	private final TokenRefresher tokenRefresher;
+	private final PrintStream out;
+	private final PrintStream err;
+
+	public CliRefresh() {
+		this(new LocalProfileStore(), new OAuthTokenRefresher(), System.out, System.err);
+	}
+
+	CliRefresh(ProfileStore profileStore, TokenRefresher tokenRefresher, PrintStream out, PrintStream err) {
+		this.profileStore = profileStore;
+		this.tokenRefresher = tokenRefresher;
+		this.out = out;
+		this.err = err;
+	}
+
+	int refresh() {
+		List<Profile> profiles = new ArrayList<>();
+		List<Profile> loadedProfiles = new ArrayList<>();
+		List<AccountRecord> accounts = new ArrayList<>();
+		RunState state = new RunState();
+		try {
+			try {
+				List<Profile> foundProfiles = profileStore.findProfiles();
+				if (foundProfiles != null) {
+					profiles.addAll(foundProfiles);
+				}
+			} catch (RuntimeException ex) {
+				state.authorizationFailure = true;
+				err.println("ERROR operation=profile_discovery");
+			}
+
+			if (!state.authorizationFailure) {
+				loadProfiles(profiles, loadedProfiles, state);
+				accounts.addAll(getAccounts(loadedProfiles));
+			}
+
+			if (!state.authorizationFailure) {
+				preflightProfiles(loadedProfiles, state);
+			}
+
+			if (!state.authorizationFailure && !state.persistenceFailure) {
+				refreshAccounts(accounts, state);
+			}
+		} finally {
+			clearProfiles(profiles, state);
+		}
+
+		finishAccounts(accounts, state);
+		printResults(profiles.size(), accounts, state.persistenceFailures);
+		if (state.persistenceFailure) {
+			return EXIT_PERSISTENCE_FAILURE;
+		} else if (state.authorizationFailure) {
+			return EXIT_AUTHORIZATION_FAILURE;
+		} else {
+			return 0;
+		}
+	}
+
+	private void loadProfiles(List<Profile> profiles, List<Profile> loadedProfiles, RunState state) {
+		for (Profile profile : profiles) {
+			boolean loaded = false;
+			try {
+				loaded = profileStore.load(profile);
+			} catch (RuntimeException ex) {
+				//Reported below without the potentially secret-bearing exception.
+			}
+			if (loaded) {
+				loadedProfiles.add(profile);
+			} else {
+				state.authorizationFailure = true;
+				err.println("ERROR profile=" + safeLabel(profile.getName()) + " operation=load");
+			}
+		}
+	}
+
+	private void preflightProfiles(List<Profile> profiles, RunState state) {
+		for (Profile profile : profiles) {
+			boolean saved = false;
+			try {
+				saved = profileStore.preflightOwners(profile);
+			} catch (RuntimeException ex) {
+				//Reported below without the potentially secret-bearing exception.
+			}
+			if (!saved) {
+				state.persistenceFailure = true;
+				state.persistenceFailures++;
+				err.println("ERROR profile=" + safeLabel(profile.getName()) + " operation=preflight_save");
+			}
+		}
+	}
+
+	private List<AccountRecord> getAccounts(List<Profile> profiles) {
+		List<AccountRecord> accounts = new ArrayList<>();
+		for (Profile profile : profiles) {
+			List<EsiOwner> owners = new ArrayList<>(profile.getEsiOwners());
+			Collections.sort(owners, new Comparator<EsiOwner>() {
+				@Override
+				public int compare(EsiOwner first, EsiOwner second) {
+					int compare = compareStrings(first.getOwnerName(), second.getOwnerName());
+					if (compare == 0) {
+						compare = compareStrings(first.getAccountID(), second.getAccountID());
+					}
+					return compare;
+				}
+			});
+			for (EsiOwner owner : owners) {
+				accounts.add(new AccountRecord(profile, owner));
+			}
+		}
+		return accounts;
+	}
+
+	private void refreshAccounts(List<AccountRecord> accounts, RunState state) {
+		Map<GrantKey, List<AccountRecord>> grants = new LinkedHashMap<>();
+		for (AccountRecord account : accounts) {
+			if (account.callbackURL == null || !isNonBlank(account.originalRefreshToken)) {
+				account.status = AccountStatus.FAILED;
+				state.authorizationFailure = true;
+				continue;
+			}
+			GrantKey key = new GrantKey(account.callbackURL, account.originalRefreshToken);
+			List<AccountRecord> grant = grants.get(key);
+			if (grant == null) {
+				grant = new ArrayList<>();
+				grants.put(key, grant);
+			}
+			grant.add(account);
+		}
+
+		Map<GrantKey, RefreshResult> cache = new HashMap<>();
+		for (Map.Entry<GrantKey, List<AccountRecord>> entry : grants.entrySet()) {
+			if (state.stopRemoteRefreshes) {
+				break;
+			}
+			GrantKey originalKey = entry.getKey();
+			List<AccountRecord> grant = entry.getValue();
+			RefreshResult result;
+			if (cache.containsKey(originalKey)) {
+				result = cache.get(originalKey);
+			} else {
+				result = refreshGrant(grant.get(0));
+				cache.put(originalKey, result);
+				if (result.isSuccessful() && isNonBlank(result.refreshToken)) {
+					cache.put(originalKey.withRefreshToken(result.refreshToken), result);
+				}
+			}
+			applyResult(grant, result, state);
+		}
+	}
+
+	private RefreshResult refreshGrant(AccountRecord representative) {
+		RefreshResult result;
+		try {
+			result = tokenRefresher.refresh(representative.owner);
+		} catch (RuntimeException ex) {
+			result = RefreshResult.failureWithRefreshToken(readRefreshToken(representative.owner));
+		}
+		if (result == null) {
+			result = RefreshResult.failure();
+		}
+		if (!result.refreshTokenObserved) {
+			result = result.withRefreshToken(readRefreshToken(representative.owner));
+		}
+		return result;
+	}
+
+	private void applyResult(List<AccountRecord> grant, RefreshResult result, RunState state) {
+		String refreshToken = result.refreshToken;
+		if (!isNonBlank(refreshToken)) {
+			restoreGrant(grant);
+			setStatus(grant, AccountStatus.FAILED);
+			state.authorizationFailure = true;
+			state.stopRemoteRefreshes = true;
+			return;
+		}
+
+		boolean success = result.isSuccessful();
+		if (!success) {
+			state.authorizationFailure = true;
+		}
+		try {
+			for (AccountRecord account : grant) {
+				account.owner.setAuth(account.callbackURL, refreshToken, null);
+				if (success) {
+					account.owner.setInvalid(false);
+				} else {
+					account.owner.setInvalid(account.originalInvalid);
+				}
+			}
+		} catch (RuntimeException ex) {
+			restoreGrant(grant);
+			setStatus(grant, AccountStatus.FAILED);
+			state.persistenceFailure = true;
+			state.persistenceFailures++;
+			state.stopRemoteRefreshes = true;
+			return;
+		}
+
+		setStatus(grant, success ? AccountStatus.SUCCEEDED : AccountStatus.FAILED);
+		Map<Profile, List<AccountRecord>> affectedProfiles = getAffectedProfiles(grant, refreshToken, success);
+		for (Map.Entry<Profile, List<AccountRecord>> entry : affectedProfiles.entrySet()) {
+			if (!saveOwners(entry.getKey())) {
+				setStatus(entry.getValue(), AccountStatus.FAILED);
+				state.persistenceFailure = true;
+				state.persistenceFailures++;
+				state.stopRemoteRefreshes = true;
+				err.println("ERROR profile=" + safeLabel(entry.getKey().getName()) + " operation=save");
+			}
+		}
+	}
+
+	private Map<Profile, List<AccountRecord>> getAffectedProfiles(List<AccountRecord> grant, String refreshToken, boolean success) {
+		Map<Profile, List<AccountRecord>> profiles = new LinkedHashMap<>();
+		for (AccountRecord account : grant) {
+			boolean tokenChanged = !account.originalRefreshToken.equals(refreshToken);
+			boolean invalidChanged = success && account.originalInvalid;
+			if (!tokenChanged && !invalidChanged) {
+				continue;
+			}
+			List<AccountRecord> affected = profiles.get(account.profile);
+			if (affected == null) {
+				affected = new ArrayList<>();
+				profiles.put(account.profile, affected);
+			}
+			affected.add(account);
+		}
+		return profiles;
+	}
+
+	private boolean saveOwners(Profile profile) {
+		for (int attempt = 0; attempt < 2; attempt++) {
+			try {
+				if (profileStore.saveOwners(profile)) {
+					return true;
+				}
+			} catch (RuntimeException ex) {
+				//Retry once without reporting the potentially secret-bearing exception.
+			}
+		}
+		return false;
+	}
+
+	private void restoreGrant(List<AccountRecord> grant) {
+		for (AccountRecord account : grant) {
+			try {
+				account.owner.setAuth(account.callbackURL, account.originalRefreshToken, null);
+				account.owner.setInvalid(account.originalInvalid);
+			} catch (RuntimeException ex) {
+				//The profile is cleared before returning from the command.
+			}
+		}
+	}
+
+	private void finishAccounts(List<AccountRecord> accounts, RunState state) {
+		for (AccountRecord account : accounts) {
+			if (account.status == null) {
+				account.status = AccountStatus.FAILED;
+				state.authorizationFailure = true;
+			}
+		}
+	}
+
+	private void clearProfiles(List<Profile> profiles, RunState state) {
+		for (Profile profile : profiles) {
+			try {
+				profileStore.clear(profile);
+			} catch (RuntimeException ex) {
+				state.authorizationFailure = true;
+				err.println("ERROR profile=" + safeLabel(profile.getName()) + " operation=cleanup");
+			}
+		}
+	}
+
+	private void printResults(int profileCount, List<AccountRecord> accounts, int persistenceFailures) {
+		int succeeded = 0;
+		for (AccountRecord account : accounts) {
+			if (account.status == AccountStatus.SUCCEEDED) {
+				succeeded++;
+				out.println("OK profile=" + safeLabel(account.profile.getName()) + " character=" + safeLabel(account.owner.getOwnerName()));
+			} else {
+				out.println("FAILED profile=" + safeLabel(account.profile.getName()) + " character=" + safeLabel(account.owner.getOwnerName()));
+			}
+		}
+		out.println("SUMMARY profiles=" + profileCount
+				+ " accounts=" + accounts.size()
+				+ " succeeded=" + succeeded
+				+ " failed=" + (accounts.size() - succeeded)
+				+ " persistence_failed=" + persistenceFailures);
+	}
+
+	private static void setStatus(List<AccountRecord> accounts, AccountStatus status) {
+		for (AccountRecord account : accounts) {
+			account.status = status;
+		}
+	}
+
+	private static String readRefreshToken(EsiOwner owner) {
+		try {
+			return owner.getRefreshToken();
+		} catch (RuntimeException ex) {
+			return null;
+		}
+	}
+
+	private static boolean isNonBlank(String value) {
+		return value != null && !value.trim().isEmpty();
+	}
+
+	private static int compareStrings(String first, String second) {
+		if (first == null && second == null) {
+			return 0;
+		} else if (first == null) {
+			return -1;
+		} else if (second == null) {
+			return 1;
+		} else {
+			return first.compareToIgnoreCase(second);
+		}
+	}
+
+	private static String safeLabel(String value) {
+		if (value == null || value.trim().isEmpty()) {
+			return "<unknown>";
+		}
+		return value.replace('\r', ' ').replace('\n', ' ').replace('\t', ' ');
+	}
+
+	interface TokenRefresher {
+		RefreshResult refresh(EsiOwner owner);
+	}
+
+	interface ProfileStore {
+		List<Profile> findProfiles();
+		boolean load(Profile profile);
+		boolean preflightOwners(Profile profile);
+		boolean saveOwners(Profile profile);
+		void clear(Profile profile);
+	}
+
+	static final class RefreshResult {
+
+		private final boolean accessTokenValid;
+		private final boolean refreshTokenObserved;
+		private final String refreshToken;
+
+		static RefreshResult fromTokens(String accessToken, String refreshToken) {
+			return new RefreshResult(isNonBlank(accessToken), true, refreshToken);
+		}
+
+		static RefreshResult failure() {
+			return new RefreshResult(false, false, null);
+		}
+
+		static RefreshResult failureWithRefreshToken(String refreshToken) {
+			return new RefreshResult(false, true, refreshToken);
+		}
+
+		private RefreshResult(boolean accessTokenValid, boolean refreshTokenObserved, String refreshToken) {
+			this.accessTokenValid = accessTokenValid;
+			this.refreshTokenObserved = refreshTokenObserved;
+			this.refreshToken = refreshToken;
+		}
+
+		private RefreshResult withRefreshToken(String refreshToken) {
+			return new RefreshResult(accessTokenValid, true, refreshToken);
+		}
+
+		boolean isSuccessful() {
+			return accessTokenValid && isNonBlank(refreshToken);
+		}
+
+	}
+
+	private static final class OAuthTokenRefresher implements TokenRefresher {
+
+		@Override
+		public RefreshResult refresh(EsiOwner owner) {
+			OAuth oauth = (OAuth) owner.getApiClient().getAuthentication(ApiClientBuilder.AUTHENTICATION);
+			oauth.setAccessToken(null);
+			String accessToken = oauth.getAccessToken();
+			String refreshToken = oauth.getRefreshToken();
+			return RefreshResult.fromTokens(accessToken, refreshToken);
+		}
+	}
+
+	private static final class LocalProfileStore implements ProfileStore {
+
+		private final ProfileManager profileManager = new ProfileManager();
+
+		@Override
+		public List<Profile> findProfiles() {
+			profileManager.searchProfile();
+			List<Profile> profiles = new ArrayList<>(profileManager.getProfiles());
+			Collections.sort(profiles);
+			return profiles;
+		}
+
+		@Override
+		public boolean load(Profile profile) {
+			profileManager.setActiveProfile(profile);
+			return profile.load();
+		}
+
+		@Override
+		public boolean preflightOwners(Profile profile) {
+			profileManager.setActiveProfile(profile);
+			return profile.preflightTable(Table.OWNERS);
+		}
+
+		@Override
+		public boolean saveOwners(Profile profile) {
+			profileManager.setActiveProfile(profile);
+			return profile.saveTableChecked(Table.OWNERS);
+		}
+
+		@Override
+		public void clear(Profile profile) {
+			profile.clear();
+		}
+	}
+
+	private static final class AccountRecord {
+
+		private final Profile profile;
+		private final EsiOwner owner;
+		private final EsiCallbackURL callbackURL;
+		private final String originalRefreshToken;
+		private final boolean originalInvalid;
+		private AccountStatus status;
+
+		private AccountRecord(Profile profile, EsiOwner owner) {
+			this.profile = profile;
+			this.owner = owner;
+			this.callbackURL = owner.getCallbackURL();
+			this.originalRefreshToken = readRefreshToken(owner);
+			this.originalInvalid = owner.isInvalid();
+		}
+	}
+
+	private static final class GrantKey {
+
+		private final String clientID;
+		private final String callbackURL;
+		private final String refreshToken;
+
+		private GrantKey(EsiCallbackURL callbackURL, String refreshToken) {
+			this.clientID = callbackURL.getA();
+			this.callbackURL = callbackURL.getUrl();
+			this.refreshToken = refreshToken;
+		}
+
+		private GrantKey withRefreshToken(String newRefreshToken) {
+			return new GrantKey(clientID, callbackURL, newRefreshToken);
+		}
+
+		private GrantKey(String clientID, String callbackURL, String refreshToken) {
+			this.clientID = clientID;
+			this.callbackURL = callbackURL;
+			this.refreshToken = refreshToken;
+		}
+
+		@Override
+		public int hashCode() {
+			int hash = 5;
+			hash = 53 * hash + Objects.hashCode(clientID);
+			hash = 53 * hash + Objects.hashCode(callbackURL);
+			hash = 53 * hash + Objects.hashCode(refreshToken);
+			return hash;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null || getClass() != obj.getClass()) {
+				return false;
+			}
+			GrantKey other = (GrantKey) obj;
+			return Objects.equals(clientID, other.clientID)
+					&& Objects.equals(callbackURL, other.callbackURL)
+					&& Objects.equals(refreshToken, other.refreshToken);
+		}
+
+	}
+
+	private static final class RunState {
+		private boolean authorizationFailure;
+		private boolean persistenceFailure;
+		private boolean stopRemoteRefreshes;
+		private int persistenceFailures;
+	}
+
+	private static enum AccountStatus {
+		SUCCEEDED,
+		FAILED
+	}
+}

--- a/src/main/java/net/nikr/eve/jeveasset/Main.java
+++ b/src/main/java/net/nikr/eve/jeveasset/Main.java
@@ -130,15 +130,19 @@ public final class Main {
 			Program.init();
 		}
 		int exitCode = 0;
-		//Update
-		if (CliOptions.get().isUpdate()) {
-			CliUpdate update = new CliUpdate();
-			exitCode = update.update();
-		}
-		//Export
-		if (CliOptions.get().isExport()) {
-			CliExport cliExport = new CliExport();
-			exitCode = cliExport.export();
+		if (CliOptions.get().isRefresh()) {
+			exitCode = new CliRefresh().refresh();
+		} else {
+			//Update
+			if (CliOptions.get().isUpdate()) {
+				CliUpdate update = new CliUpdate();
+				exitCode = update.update();
+			}
+			//Export
+			if (CliOptions.get().isExport()) {
+				CliExport cliExport = new CliExport();
+				exitCode = cliExport.export();
+			}
 		}
 		if (CliOptions.get().isCLI()) {
 			System.exit(exitCode);

--- a/src/main/java/net/nikr/eve/jeveasset/data/profile/Profile.java
+++ b/src/main/java/net/nikr/eve/jeveasset/data/profile/Profile.java
@@ -22,6 +22,9 @@
 package net.nikr.eve.jeveasset.data.profile;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import net.nikr.eve.jeveasset.Program;
@@ -79,20 +82,45 @@ public class Profile implements Comparable<Profile> {
 	}
 
 	public void saveTable(Table table) {
+		saveTableChecked(table);
+	}
+
+	public boolean saveTableChecked(Table table) {
 		if (type == ProfileType.XML) {
-			save(); //Full save
+			return saveChecked(); //Full save
 		} else {
-			ProfileDatabase.save(this, table);
+			return ProfileDatabase.save(this, table);
 		}
 	}
 
 	public void save() {
+		saveChecked();
+	}
+
+	public boolean saveChecked() {
 		boolean save = ProfileDatabase.save(this);
-		if (save && type == ProfileType.XML) {
-			type = ProfileType.SQLITE; //Migrated to SQLite
+		if (!save) {
+			return false;
+		}
+		if (type == ProfileType.XML) {
 			File file = new File(getXmlFilename());
 			File backup = new File(getBackupXmlFilename());
-			file.renameTo(backup);
+			try {
+				Files.move(file.toPath(), backup.toPath(), StandardCopyOption.REPLACE_EXISTING);
+			} catch (IOException ex) {
+				LOG.warn("Failed to migrate profile: {}", getName());
+				return false;
+			}
+			type = ProfileType.SQLITE; //Migrated to SQLite
+		}
+		return true;
+	}
+
+	public boolean preflightTable(Table table) {
+		if (type == ProfileType.XML) {
+			return saveChecked(); //Migrate before remote changes can happen
+		} else {
+			return ProfileDatabase.preflight(this, table);
 		}
 	}
 

--- a/src/main/java/net/nikr/eve/jeveasset/io/local/profile/ProfileDatabase.java
+++ b/src/main/java/net/nikr/eve/jeveasset/io/local/profile/ProfileDatabase.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -204,6 +206,41 @@ public class ProfileDatabase {
 
 	public static boolean save(Profile profile, Table table) {
 		return save(profile, Collections.singleton(table));
+	}
+
+	public static boolean preflight(Profile profile, Table table) {
+		String connectionUrl = getConnectionUrl(profile.getSQLiteFilename());
+		waitForUpdates();
+		try (Connection connection = DriverManager.getConnection(connectionUrl);) {
+			try {
+				connection.setAutoCommit(false);
+				boolean full = table.isEmpty(connection);
+				if (table == Table.OWNERS && !full && !ownersCountMatches(connection, profile)) {
+					connection.rollback();
+					connection.setAutoCommit(true);
+					return false;
+				}
+				table.create(connection);
+				table.updateTable(connection);
+				table.insert(connection, profile.getEsiOwners(), full);
+				connection.rollback();
+				connection.setAutoCommit(true);
+				return true;
+			} catch (SQLException ex) {
+				connection.rollback();
+				return false;
+			}
+		} catch (SQLException ex) {
+			return false;
+		}
+	}
+
+	private static boolean ownersCountMatches(Connection connection, Profile profile) throws SQLException {
+		String sql = "SELECT COUNT(*) FROM owners";
+		try (PreparedStatement statement = connection.prepareStatement(sql);
+				ResultSet result = statement.executeQuery();) {
+			return result.next() && result.getInt(1) == profile.getEsiOwners().size();
+		}
 	}
 
 	private static boolean save(Profile profile, Table[] tables) {

--- a/src/test/java/net/nikr/eve/jeveasset/CliOptionsTest.java
+++ b/src/test/java/net/nikr/eve/jeveasset/CliOptionsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2009-2026 Contributors (see credits.txt)
+ *
+ * This file is part of jEveAssets.
+ *
+ * jEveAssets is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * jEveAssets is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jEveAssets; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package net.nikr.eve.jeveasset;
+
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import picocli.CommandLine;
+
+
+public class CliOptionsTest {
+
+	@Test
+	public void refreshOptionsEnableCliModeAndAreExclusive() {
+		for (String option : new String[] {"-r", "-refresh"}) {
+			CliOptions options = parse(option);
+			assertTrue(options.isRefresh());
+			assertTrue(options.isCLI());
+			assertFalse(options.isUpdate());
+			assertFalse(options.isExport());
+		}
+		assertInvalid("-r", "-u");
+		assertInvalid("-refresh", "-export", "-csv");
+	}
+
+	private CliOptions parse(String... args) {
+		CliOptions options = new CliOptions();
+		options.parse(args);
+		return options;
+	}
+
+	private void assertInvalid(String... args) {
+		try {
+			parse(args);
+			fail("Expected invalid CLI option combination");
+		} catch (CommandLine.ParameterException ex) {
+			//Expected
+		}
+	}
+}

--- a/src/test/java/net/nikr/eve/jeveasset/CliRefreshTest.java
+++ b/src/test/java/net/nikr/eve/jeveasset/CliRefreshTest.java
@@ -1,0 +1,393 @@
+/*
+ * Copyright 2009-2026 Contributors (see credits.txt)
+ *
+ * This file is part of jEveAssets.
+ *
+ * jEveAssets is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * jEveAssets is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jEveAssets; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package net.nikr.eve.jeveasset;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.nikr.eve.jeveasset.CliRefresh.ProfileStore;
+import net.nikr.eve.jeveasset.CliRefresh.RefreshResult;
+import net.nikr.eve.jeveasset.CliRefresh.TokenRefresher;
+import net.nikr.eve.jeveasset.data.api.accounts.EsiOwner;
+import net.nikr.eve.jeveasset.data.profile.Profile;
+import net.nikr.eve.jeveasset.data.profile.Profile.ProfileType;
+import net.nikr.eve.jeveasset.io.esi.EsiCallbackURL;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class CliRefreshTest {
+
+	private static int secretID;
+
+	private ByteArrayOutputStream stdout;
+	private ByteArrayOutputStream stderr;
+
+	@Before
+	public void setUp() {
+		stdout = new ByteArrayOutputStream();
+		stderr = new ByteArrayOutputStream();
+	}
+
+	@Test
+	public void rotationIsPersistedBeforeNextGrantWithStableSecretSafeOutput() {
+		String oldRefresh = secret("refresh-old");
+		String newRefresh = secret("refresh-new");
+		String unchangedRefresh = secret("refresh-unchanged");
+		String firstAccess = secret("access-first");
+		String secondAccess = secret("access-second");
+		EsiOwner alice = owner("alice", "Alice", oldRefresh, true);
+		Profile profile = profile("Default",
+				owner("bob", "Bob", unchangedRefresh, false),
+				alice);
+		List<String> events = new ArrayList<>();
+		FakeProfileStore store = new FakeProfileStore(events, profile);
+		FakeTokenRefresher refresher = new FakeTokenRefresher(events);
+		refresher.result("alice", RefreshResult.fromTokens(firstAccess, newRefresh));
+		refresher.result("bob", RefreshResult.fromTokens(secondAccess, unchangedRefresh));
+
+		int exitCode = run(store, refresher);
+
+		assertNoSecrets(oldRefresh, newRefresh, unchangedRefresh, firstAccess, secondAccess);
+		assertEquals(0, exitCode);
+		assertEquals("OK profile=Default character=Alice" + System.lineSeparator()
+				+ "OK profile=Default character=Bob" + System.lineSeparator()
+				+ "SUMMARY profiles=1 accounts=2 succeeded=2 failed=0 persistence_failed=0" + System.lineSeparator(), output());
+		assertEquals("", errorOutput());
+		assertEquals(newRefresh, alice.getRefreshToken());
+		assertFalse(alice.isInvalid());
+		assertEquals(1, store.saveCount(profile));
+		assertTrue(events.indexOf("remote:alice") < events.indexOf("save:Default"));
+		assertTrue(events.indexOf("save:Default") < events.indexOf("remote:bob"));
+		assertEquals(Arrays.asList(profile), store.clearedProfiles);
+	}
+
+	@Test
+	public void rotationSurvivesRuntimeFailureAndIsNotCachedAsSuccess() {
+		String oldRefresh = secret("refresh-failed-old");
+		String newRefresh = secret("refresh-failed-new");
+		String access = secret("access-replacement");
+		String rawError = secret("raw-error");
+		EsiOwner failedOwner = owner("old", "Alice", oldRefresh, true);
+		Profile failedProfile = profile("First", failedOwner);
+		Profile replacementProfile = profile("Second", owner("new", "Bob", newRefresh, false));
+		List<String> events = new ArrayList<>();
+		FakeProfileStore store = new FakeProfileStore(events, failedProfile, replacementProfile);
+		FakeTokenRefresher refresher = new FakeTokenRefresher(events);
+		refresher.runtimeFailureAfterRotation("old", EsiCallbackURL.LOCALHOST, newRefresh, rawError);
+		refresher.result("new", RefreshResult.fromTokens(access, newRefresh));
+
+		int exitCode = run(store, refresher);
+
+		assertNoSecrets(oldRefresh, newRefresh, access, rawError);
+		assertEquals(CliRefresh.EXIT_AUTHORIZATION_FAILURE, exitCode);
+		assertEquals(Arrays.asList("old", "new"), refresher.calls);
+		assertEquals(newRefresh, failedOwner.getRefreshToken());
+		assertTrue(failedOwner.isInvalid());
+		assertEquals(1, store.saveCount(failedProfile));
+		assertEquals(0, store.saveCount(replacementProfile));
+		assertEquals("FAILED profile=First character=Alice" + System.lineSeparator()
+				+ "OK profile=Second character=Bob" + System.lineSeparator()
+				+ "SUMMARY profiles=2 accounts=2 succeeded=1 failed=1 persistence_failed=0" + System.lineSeparator(), output());
+	}
+
+	@Test
+	public void blankReplacementRestoresOriginalAndStopsRemoteRefreshes() {
+		String oldRefresh = secret("refresh-old-blank");
+		String secondRefresh = secret("refresh-second-blank");
+		String access = secret("access-blank");
+		EsiOwner first = owner("first", "Alice", oldRefresh, true);
+		Profile profile = profile("Default", first, owner("second", "Bob", secondRefresh, false));
+		List<String> events = new ArrayList<>();
+		FakeProfileStore store = new FakeProfileStore(events, profile);
+		FakeTokenRefresher refresher = new FakeTokenRefresher(events);
+		refresher.result("first", RefreshResult.fromTokens(access, " "));
+		refresher.result("second", RefreshResult.fromTokens(access, secondRefresh));
+
+		int exitCode = run(store, refresher);
+
+		assertNoSecrets(oldRefresh, secondRefresh, access);
+		assertEquals(CliRefresh.EXIT_AUTHORIZATION_FAILURE, exitCode);
+		assertEquals(Arrays.asList("first"), refresher.calls);
+		assertEquals(oldRefresh, first.getRefreshToken());
+		assertTrue(first.isInvalid());
+		assertEquals(0, store.saveCount(profile));
+	}
+
+	@Test
+	public void preflightFailureMakesNoRemoteRequestAndCleansUp() {
+		String refresh = secret("refresh-preflight-failure");
+		Profile profile = profile("Default", owner("one", "Alice", refresh, false));
+		List<String> events = new ArrayList<>();
+		FakeProfileStore store = new FakeProfileStore(events, profile);
+		store.failPreflight(profile);
+		FakeTokenRefresher refresher = new FakeTokenRefresher(events);
+
+		int exitCode = run(store, refresher);
+
+		assertNoSecrets(refresh);
+		assertEquals(CliRefresh.EXIT_PERSISTENCE_FAILURE, exitCode);
+		assertTrue(refresher.calls.isEmpty());
+		assertEquals(1, store.preflightCount(profile));
+		assertEquals(Arrays.asList(profile), store.clearedProfiles);
+	}
+
+	@Test
+	public void unrecoverableSaveFailureRetriesLocallyAndStopsRemoteRefreshes() {
+		String firstOld = secret("refresh-first-old-save-failure");
+		String firstNew = secret("refresh-first-new-save-failure");
+		String secondRefresh = secret("refresh-second-save-failure");
+		String access = secret("access-save-failure");
+		String rawError = secret("save-error");
+		Profile profile = profile("Default",
+				owner("first", "Alice", firstOld, false),
+				owner("second", "Bob", secondRefresh, false));
+		List<String> events = new ArrayList<>();
+		FakeProfileStore store = new FakeProfileStore(events, profile);
+		store.saveResults(profile, new RuntimeException(rawError), false);
+		FakeTokenRefresher refresher = new FakeTokenRefresher(events);
+		refresher.result("first", RefreshResult.fromTokens(access, firstNew));
+		refresher.result("second", RefreshResult.fromTokens(access, secondRefresh));
+
+		int exitCode = run(store, refresher);
+
+		assertNoSecrets(firstOld, firstNew, secondRefresh, access, rawError);
+		assertEquals(CliRefresh.EXIT_PERSISTENCE_FAILURE, exitCode);
+		assertEquals(Arrays.asList("first"), refresher.calls);
+		assertEquals(2, store.saveCount(profile));
+		assertTrue(output().contains("succeeded=0 failed=2 persistence_failed=1"));
+	}
+
+	@Test
+	public void grantIdentityDeduplicatesOnlyEquivalentOldAndRotatedTokens() {
+		String oldRefresh = secret("refresh-cache-old");
+		String newRefresh = secret("refresh-cache-new");
+		String otherRefresh = secret("refresh-cache-other");
+		String access = secret("access-cache");
+		EsiOwner firstOwner = owner("first", "Alice", oldRefresh, false);
+		EsiOwner duplicateOwner = owner("duplicate", "Bob", oldRefresh, false);
+		Profile first = profile("First", firstOwner);
+		Profile duplicate = profile("Duplicate", duplicateOwner);
+		Profile replacement = profile("Replacement", owner("replacement", "Carol", newRefresh, false));
+		Profile otherToken = profile("Other Token", owner("other", "Alice", otherRefresh, false));
+		Profile otherCallback = profile("Other Callback",
+				owner("callback", "Alice", oldRefresh, false, EsiCallbackURL.EVE_NIKR_NET));
+		List<String> events = new ArrayList<>();
+		FakeProfileStore store = new FakeProfileStore(events, first, duplicate, replacement, otherToken, otherCallback);
+		FakeTokenRefresher refresher = new FakeTokenRefresher(events);
+		refresher.result("first", RefreshResult.fromTokens(access, newRefresh));
+		refresher.result("other", RefreshResult.fromTokens(access, otherRefresh));
+		refresher.result("callback", RefreshResult.fromTokens(access, oldRefresh));
+
+		int exitCode = run(store, refresher);
+
+		assertNoSecrets(oldRefresh, newRefresh, otherRefresh, access);
+		assertEquals(0, exitCode);
+		assertEquals(Arrays.asList("first", "other", "callback"), refresher.calls);
+		assertEquals(newRefresh, firstOwner.getRefreshToken());
+		assertEquals(newRefresh, duplicateOwner.getRefreshToken());
+		assertEquals(1, store.saveCount(first));
+		assertEquals(1, store.saveCount(duplicate));
+		assertEquals(0, store.saveCount(replacement));
+		assertEquals(0, store.saveCount(otherToken));
+		assertEquals(0, store.saveCount(otherCallback));
+	}
+
+	private int run(FakeProfileStore store, FakeTokenRefresher refresher) {
+		PrintStream out = new PrintStream(stdout, true);
+		PrintStream err = new PrintStream(stderr, true);
+		return new CliRefresh(store, refresher, out, err).refresh();
+	}
+
+	private String output() {
+		return new String(stdout.toByteArray(), StandardCharsets.UTF_8);
+	}
+
+	private String errorOutput() {
+		return new String(stderr.toByteArray(), StandardCharsets.UTF_8);
+	}
+
+	private void assertNoSecrets(String... secrets) {
+		String output = output();
+		String errors = errorOutput();
+		for (String secret : secrets) {
+			assertFalse("stdout contained secret material", output.contains(secret));
+			assertFalse("stderr contained secret material", errors.contains(secret));
+		}
+	}
+
+	private static String secret(String label) {
+		secretID++;
+		return "test-private-" + label + "-" + secretID;
+	}
+
+	private static Profile profile(String name, EsiOwner... owners) {
+		Profile profile = new Profile(name, false, false, ProfileType.SQLITE);
+		profile.getEsiOwners().addAll(Arrays.asList(owners));
+		return profile;
+	}
+
+	private static EsiOwner owner(String accountID, String character, String refreshToken, boolean invalid) {
+		return owner(accountID, character, refreshToken, invalid, EsiCallbackURL.LOCALHOST);
+	}
+
+	private static EsiOwner owner(String accountID, String character, String refreshToken, boolean invalid, EsiCallbackURL callbackURL) {
+		EsiOwner owner = new EsiOwner(accountID);
+		owner.setOwnerName(character);
+		owner.setAuth(callbackURL, refreshToken, null);
+		owner.setInvalid(invalid);
+		return owner;
+	}
+
+	private static class FakeTokenRefresher implements TokenRefresher {
+
+		private final List<String> events;
+		private final Map<String, Object> results = new HashMap<>();
+		private final List<String> calls = new ArrayList<>();
+
+		private FakeTokenRefresher(List<String> events) {
+			this.events = events;
+		}
+
+		private void result(String accountID, RefreshResult result) {
+			results.put(accountID, result);
+		}
+
+		private void runtimeFailureAfterRotation(String accountID, EsiCallbackURL callbackURL, String refreshToken, String message) {
+			results.put(accountID, new RotationFailure(callbackURL, refreshToken, message));
+		}
+
+		@Override
+		public RefreshResult refresh(EsiOwner owner) {
+			String accountID = owner.getAccountID();
+			calls.add(accountID);
+			events.add("remote:" + accountID);
+			Object result = results.get(accountID);
+			if (result instanceof RotationFailure) {
+				RotationFailure failure = (RotationFailure) result;
+				owner.setAuth(failure.callbackURL, failure.refreshToken, null);
+				throw failure.exception;
+			} else if (result instanceof RefreshResult) {
+				return (RefreshResult) result;
+			} else {
+				return RefreshResult.failure();
+			}
+		}
+	}
+
+	private static class RotationFailure {
+
+		private final EsiCallbackURL callbackURL;
+		private final String refreshToken;
+		private final RuntimeException exception;
+
+		private RotationFailure(EsiCallbackURL callbackURL, String refreshToken, String message) {
+			this.callbackURL = callbackURL;
+			this.refreshToken = refreshToken;
+			this.exception = new RuntimeException(message);
+		}
+	}
+
+	private static class FakeProfileStore implements ProfileStore {
+
+		private final List<String> events;
+		private final List<Profile> profiles;
+		private final Map<Profile, Boolean> preflightResults = new HashMap<>();
+		private final Map<Profile, List<Object>> saveResults = new HashMap<>();
+		private final Map<Profile, Integer> saveCounts = new HashMap<>();
+		private final Map<Profile, Integer> preflightCounts = new HashMap<>();
+		private final List<Profile> clearedProfiles = new ArrayList<>();
+
+		private FakeProfileStore(List<String> events, Profile... profiles) {
+			this.events = events;
+			this.profiles = Arrays.asList(profiles);
+		}
+
+		private void failPreflight(Profile profile) {
+			preflightResults.put(profile, Boolean.FALSE);
+		}
+
+		private void saveResults(Profile profile, Object... results) {
+			saveResults.put(profile, new ArrayList<>(Arrays.asList(results)));
+		}
+
+		private int saveCount(Profile profile) {
+			Integer count = saveCounts.get(profile);
+			return count == null ? 0 : count;
+		}
+
+		private int preflightCount(Profile profile) {
+			Integer count = preflightCounts.get(profile);
+			return count == null ? 0 : count;
+		}
+
+		@Override
+		public List<Profile> findProfiles() {
+			events.add("find");
+			return new ArrayList<>(profiles);
+		}
+
+		@Override
+		public boolean load(Profile profile) {
+			events.add("load:" + profile.getName());
+			return true;
+		}
+
+		@Override
+		public boolean preflightOwners(Profile profile) {
+			events.add("preflight:" + profile.getName());
+			Integer count = preflightCounts.get(profile);
+			preflightCounts.put(profile, count == null ? 1 : count + 1);
+			Boolean result = preflightResults.get(profile);
+			return result == null || result;
+		}
+
+		@Override
+		public boolean saveOwners(Profile profile) {
+			events.add("save:" + profile.getName());
+			int count = saveCount(profile);
+			saveCounts.put(profile, count + 1);
+			List<Object> results = saveResults.get(profile);
+			if (results == null || count >= results.size()) {
+				return true;
+			}
+			Object result = results.get(count);
+			if (result instanceof RuntimeException) {
+				throw (RuntimeException) result;
+			}
+			return Boolean.TRUE.equals(result);
+		}
+
+		@Override
+		public void clear(Profile profile) {
+			events.add("clear:" + profile.getName());
+			clearedProfiles.add(profile);
+		}
+	}
+}

--- a/src/test/java/net/nikr/eve/jeveasset/data/profile/ProfileRefreshPersistenceTest.java
+++ b/src/test/java/net/nikr/eve/jeveasset/data/profile/ProfileRefreshPersistenceTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2009-2026 Contributors (see credits.txt)
+ *
+ * This file is part of jEveAssets.
+ *
+ * jEveAssets is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * jEveAssets is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jEveAssets; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+package net.nikr.eve.jeveasset.data.profile;
+
+import ch.qos.logback.classic.Level;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import net.nikr.eve.jeveasset.Program;
+import net.nikr.eve.jeveasset.TestUtil;
+import net.nikr.eve.jeveasset.data.api.accounts.EsiOwner;
+import net.nikr.eve.jeveasset.data.profile.Profile.ProfileType;
+import net.nikr.eve.jeveasset.io.esi.EsiCallbackURL;
+import net.nikr.eve.jeveasset.io.local.profile.ProfileDatabase.Table;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class ProfileRefreshPersistenceTest extends TestUtil {
+
+	private static int testID;
+
+	@BeforeClass
+	public static void setUpClass() {
+		setLoggingLevel(Level.OFF);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		setLoggingLevel(Level.INFO);
+	}
+
+	@Test
+	public void sqlitePreflightRollsBackAndCheckedSavePersistsRotation() {
+		String oldRefresh = secret("sqlite-old");
+		String newRefresh = secret("sqlite-new");
+		Profile profile = sqliteProfile("Refresh Persistence");
+		try {
+			EsiOwner owner = owner("account", "Alice", oldRefresh, true);
+			profile.getEsiOwners().add(owner);
+			assertTrue(profile.saveChecked());
+
+			owner.setAuth(EsiCallbackURL.LOCALHOST, newRefresh, null);
+			owner.setInvalid(false);
+			assertTrue(profile.preflightTable(Table.OWNERS));
+
+			Profile preflightReload = sqliteCopy(profile);
+			assertTrue(preflightReload.load());
+			assertEquals(1, preflightReload.getEsiOwners().size());
+			assertTrue("preflight changed the stored refresh token", oldRefresh.equals(preflightReload.getEsiOwners().get(0).getRefreshToken()));
+			assertTrue("preflight changed the stored invalid flag", preflightReload.getEsiOwners().get(0).isInvalid());
+
+			assertTrue(profile.saveTableChecked(Table.OWNERS));
+			Profile savedReload = sqliteCopy(profile);
+			assertTrue(savedReload.load());
+			assertEquals(1, savedReload.getEsiOwners().size());
+			assertTrue("rotated refresh token was not stored", newRefresh.equals(savedReload.getEsiOwners().get(0).getRefreshToken()));
+			assertFalse("valid state was not stored", savedReload.getEsiOwners().get(0).isInvalid());
+		} finally {
+			cleanup(profile);
+		}
+	}
+
+	@Test
+	public void sqlitePreflightRejectsOwnersSkippedDuringLoad() throws SQLException {
+		String refresh = secret("unknown-callback");
+		Profile profile = sqliteProfile("Unknown Callback");
+		try {
+			profile.getEsiOwners().add(owner("account", "Alice", refresh, false));
+			assertTrue(profile.saveChecked());
+			try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + profile.getSQLiteFilename());
+					PreparedStatement statement = connection.prepareStatement("UPDATE owners SET callbackurl = ?")) {
+				statement.setString(1, "FUTURE_CALLBACK");
+				assertEquals(1, statement.executeUpdate());
+			}
+
+			Profile loaded = sqliteCopy(profile);
+			assertTrue(loaded.load());
+			assertTrue(loaded.getEsiOwners().isEmpty());
+			assertFalse(loaded.preflightTable(Table.OWNERS));
+
+			try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + profile.getSQLiteFilename());
+					PreparedStatement statement = connection.prepareStatement("SELECT COUNT(*) FROM owners");
+					ResultSet result = statement.executeQuery()) {
+				assertTrue(result.next());
+				assertEquals(1, result.getInt(1));
+			}
+		} finally {
+			cleanup(profile);
+		}
+	}
+
+	@Test
+	public void legacyXmlMigrationIsCheckedAndKeepsRotatedToken() throws IOException {
+		String oldRefresh = secret("legacy-old");
+		String newRefresh = secret("legacy-new");
+		Profile profile = xmlProfile("Legacy Refresh");
+		try {
+			String xml = "<assets><esiowners><esiowner accountname=\"Account\" refreshtoken=\"" + oldRefresh
+					+ "\" scopes=\"\" structuresnextupdate=\"0\" accountnextupdate=\"0\" callbackurl=\"LOCALHOST\""
+					+ " name=\"Alice\" id=\"1\" invalid=\"true\"/></esiowners></assets>";
+			write(profile.getXmlFilename(), xml);
+			write(profile.getBackupXmlFilename(), "stale backup");
+			assertTrue(profile.load());
+			assertEquals(1, profile.getEsiOwners().size());
+			assertTrue(profile.preflightTable(Table.OWNERS));
+			assertFalse(new File(profile.getXmlFilename()).exists());
+			assertTrue(new File(profile.getBackupXmlFilename()).exists());
+			assertEquals(xml, read(profile.getBackupXmlFilename()));
+			assertTrue(new File(profile.getSQLiteFilename()).exists());
+
+			profile.getEsiOwners().get(0).setAuth(EsiCallbackURL.LOCALHOST, newRefresh, null);
+			profile.getEsiOwners().get(0).setInvalid(false);
+			assertTrue(profile.saveTableChecked(Table.OWNERS));
+
+			Profile reloaded = sqliteCopy(profile);
+			assertTrue(reloaded.load());
+			assertEquals(1, reloaded.getEsiOwners().size());
+			assertTrue("legacy rotation was not stored", newRefresh.equals(reloaded.getEsiOwners().get(0).getRefreshToken()));
+			assertFalse("legacy invalid flag was not cleared", reloaded.getEsiOwners().get(0).isInvalid());
+		} finally {
+			cleanup(profile);
+		}
+	}
+
+	private static Profile sqliteProfile(String name) {
+		testID++;
+		return new Profile(name + " " + testID, false, false, ProfileType.SQLITE);
+	}
+
+	private static Profile xmlProfile(String name) {
+		testID++;
+		return new Profile(name + " " + testID, false, false, ProfileType.XML);
+	}
+
+	private static Profile sqliteCopy(Profile profile) {
+		return new Profile(profile.getName(), false, false, ProfileType.SQLITE);
+	}
+
+	private static EsiOwner owner(String accountID, String character, String refreshToken, boolean invalid) {
+		EsiOwner owner = new EsiOwner(accountID);
+		owner.setOwnerName(character);
+		owner.setAuth(EsiCallbackURL.LOCALHOST, refreshToken, null);
+		owner.setInvalid(invalid);
+		return owner;
+	}
+
+	private static String secret(String label) {
+		return "test-private-" + label + "-" + testID;
+	}
+
+	private static void write(String filename, String value) throws IOException {
+		Path path = Paths.get(filename);
+		Files.createDirectories(path.getParent());
+		Files.write(path, value.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static String read(String filename) throws IOException {
+		return new String(Files.readAllBytes(Paths.get(filename)), StandardCharsets.UTF_8);
+	}
+
+	private static void cleanup(Profile profile) {
+		profile.getStockpileIDs().removeTable();
+		delete(getProgramBackupFilename(profile.getXmlFilename()));
+		delete(profile.getXmlFilename());
+		delete(profile.getBackupXmlFilename());
+		delete(profile.getSQLiteFilename());
+		delete(profile.getBackupSQLiteFilename());
+	}
+
+	private static String getProgramBackupFilename(String filename) {
+		return filename.substring(0, filename.lastIndexOf('.'))
+				+ "_" + Program.PROGRAM_VERSION.replace(" ", "_") + "_backup.zip";
+	}
+
+	private static void delete(String filename) {
+		File file = new File(filename);
+		if (file.exists()) {
+			assertTrue("test file cleanup failed", file.delete());
+		}
+	}
+}


### PR DESCRIPTION
Hi,

I reached out on Discord before starting this PR. It attempts to solve refresh ESI token pains raised in issue #540.

ESI authorizations can stop working when jEveAssets is not used for a longer time and with all chars needing re-auth to properly see the assets again. Until now, keeping them active required a normal data update. This also downloads account data, even when only the authorization needs to be refreshed.

This PR adds a small first step:

- new `-r` and `-refresh` CLI options
- refreshes authorizations for all profiles and accounts w/o full ESI data load
- saves rotated refresh tokens immediately
- adds tests

Not in scope for this PR (but coming up):
- add GUI scheduler

How to use:

```text
java "-Djava.awt.headless=true" -jar jeveassets.jar -r
```

No other jEveAssets instance can be running while this command runs. It can be called by an external scheduler.